### PR TITLE
Fix multibyte ui

### DIFF
--- a/plt_linux.go
+++ b/plt_linux.go
@@ -7,11 +7,12 @@ package main
 
 import (
 	"bufio"
-	tm "github.com/nsf/termbox-go"
 	"net"
 	"os"
 	"strconv"
 	"strings"
+
+	tm "github.com/nsf/termbox-go"
 )
 
 type ethrNetDevInfo struct {

--- a/plt_windows.go
+++ b/plt_windows.go
@@ -6,11 +6,12 @@
 package main
 
 import (
-	tm "github.com/nsf/termbox-go"
 	"net"
 	"strings"
 	"syscall"
 	"unsafe"
+
+	tm "github.com/nsf/termbox-go"
 )
 
 var kernel32 = syscall.NewLazyDLL("kernel32.dll")

--- a/serverui.go
+++ b/serverui.go
@@ -8,11 +8,12 @@ package main
 import (
 	"errors"
 	"fmt"
-	tm "github.com/nsf/termbox-go"
 	"os"
 	"sync"
 	"sync/atomic"
 	"time"
+
+	tm "github.com/nsf/termbox-go"
 )
 
 type ethrTestResultAggregate struct {

--- a/ui.go
+++ b/ui.go
@@ -10,6 +10,7 @@ import (
 	"math"
 	"time"
 
+	"github.com/mattn/go-runewidth"
 	tm "github.com/nsf/termbox-go"
 )
 
@@ -55,6 +56,12 @@ type table struct {
 	cr      int
 	justify int
 	border  int
+}
+
+func init() {
+	if runewidth.IsEastAsian() {
+		symbols = []rune{'+', '-', '+', '|', '+', '+', '+', '+', '+', '+', '+', ' ', '░', '▒', '▓', '█', '^', 'v'}
+	}
 }
 
 func (t *table) drawTblRow(ledge, redge, middle, spr rune, fg, bg tm.Attribute) {

--- a/ui.go
+++ b/ui.go
@@ -7,9 +7,10 @@ package main
 
 import (
 	"fmt"
-	tm "github.com/nsf/termbox-go"
 	"math"
 	"time"
+
+	tm "github.com/nsf/termbox-go"
 )
 
 const (

--- a/ui.go
+++ b/ui.go
@@ -136,8 +136,12 @@ func printHLineText(x, y int, w int, text string) {
 	}
 	offset := (w - runewidth.StringWidth(text)) / 2
 	textArr := []rune(text)
+	xoff := 0
 	for i := 0; i < len(text); i++ {
-		tm.SetCell(x+offset+i, y, textArr[i], tm.ColorWhite, tm.ColorDefault)
+		tm.SetCell(x+offset+i+xoff, y, textArr[i], tm.ColorWhite, tm.ColorDefault)
+		if runewidth.RuneWidth(textArr[i]) == 2 {
+			xoff++
+		}
 	}
 }
 
@@ -153,8 +157,12 @@ func printText(x, y, w int, text string, fg, bg tm.Attribute) {
 	for i := 0; i < w; i++ {
 		tm.SetCell(x+i, y, ' ', fg, bg)
 	}
+	xoff := 0
 	for i := 0; i < len(textArr); i++ {
-		tm.SetCell(x+i, y, textArr[i], fg, bg)
+		tm.SetCell(x+i+xoff, y, textArr[i], fg, bg)
+		if runewidth.RuneWidth(textArr[i]) == 2 {
+			xoff++
+		}
 	}
 }
 
@@ -164,8 +172,12 @@ func printCenterText(x, y, w int, text string, fg, bg tm.Attribute) {
 	for i := 0; i < w; i++ {
 		tm.SetCell(x+i, y, ' ', fg, bg)
 	}
+	xoff := 0
 	for i := 0; i < len(textArr); i++ {
-		tm.SetCell(x+offset+i, y, textArr[i], fg, bg)
+		tm.SetCell(x+offset+i+xoff, y, textArr[i], fg, bg)
+		if runewidth.RuneWidth(textArr[i]) == 2 {
+			xoff++
+		}
 	}
 }
 

--- a/ui.go
+++ b/ui.go
@@ -134,7 +134,7 @@ func printHLineText(x, y int, w int, text string) {
 	for i := 0; i < w; i++ {
 		tm.SetCell(x+i, y, symbols[horizontal], tm.ColorWhite, tm.ColorDefault)
 	}
-	offset := (w - len(text)) / 2
+	offset := (w - runewidth.StringWidth(text)) / 2
 	textArr := []rune(text)
 	for i := 0; i < len(text); i++ {
 		tm.SetCell(x+offset+i, y, textArr[i], tm.ColorWhite, tm.ColorDefault)
@@ -159,7 +159,7 @@ func printText(x, y, w int, text string, fg, bg tm.Attribute) {
 }
 
 func printCenterText(x, y, w int, text string, fg, bg tm.Attribute) {
-	offset := (w - len(text)) / 2
+	offset := (w - runewidth.StringWidth(text)) / 2
 	textArr := []rune(text)
 	for i := 0; i < w; i++ {
 		tm.SetCell(x+i, y, ' ', fg, bg)


### PR DESCRIPTION
On East Asian locales like CJK, interface name have multi-byte letters. (ex: ローカルエリア接続) And also, Windows command prompt on CJK draw strange characters which have different withds to non-CJK console.

![image](https://user-images.githubusercontent.com/10111/49484489-8f610980-f87a-11e8-8a6b-3d4e13617388.png)

This change fix location to draw multi-byte letter. And change to use ASCII letters for borders on CJK.

![image](https://user-images.githubusercontent.com/10111/49484506-a56eca00-f87a-11e8-9ed1-ce7726518341.png)

