### PR TITLE
Add files without extension to .gitigore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,8 @@
 
 # Log files
 *.log
+
+# Files without extension (Linux binary, for example)
+*
+!/**/
+!*.*


### PR DESCRIPTION
Small fix to ignore all files without extension - like the output of `go build` for non-Windows.