### PR TITLE
Misc/codecleanup

### DIFF
--- a/client.go
+++ b/client.go
@@ -8,7 +8,7 @@ package main
 import (
 	"bytes"
 	"encoding/gob"
-//	"fmt"
+	//	"fmt"
 	"io"
 	"io/ioutil"
 	"net"
@@ -57,24 +57,24 @@ func establishSession(testParam EthrTestParam, server string) (err error, test *
 		sendSessionMsg(enc, ethrMsg)
 		return
 	}
-    // TODO: Enable this in future, right now there is not much value coming
-    // from this.
-    /**
-	ethrMsg = recvSessionMsg(test.dec)
-	if ethrMsg.Type != EthrAck {
-		if ethrMsg.Type == EthrFin {
-			err = fmt.Errorf("%s", ethrMsg.Fin.Message)
-		} else {
-			err = fmt.Errorf("Unexpected control message received. %v", ethrMsg)
+	// TODO: Enable this in future, right now there is not much value coming
+	// from this.
+	/**
+		ethrMsg = recvSessionMsg(test.dec)
+		if ethrMsg.Type != EthrAck {
+			if ethrMsg.Type == EthrFin {
+				err = fmt.Errorf("%s", ethrMsg.Fin.Message)
+			} else {
+				err = fmt.Errorf("Unexpected control message received. %v", ethrMsg)
+			}
+			deleteTest(test)
 		}
-		deleteTest(test)
-	}
-	ethrMsg = createAckMsg()
-	err = sendSessionMsg(test.enc, ethrMsg)
-	if err != nil {
-		os.Exit(1)
-	}
-    **/
+		ethrMsg = createAckMsg()
+		err = sendSessionMsg(test.enc, ethrMsg)
+		if err != nil {
+			os.Exit(1)
+		}
+	    **/
 	return
 }
 
@@ -111,9 +111,9 @@ func runDurationTimer(d time.Duration, toStop chan int) {
 
 func clientWatchControlChannel(test *ethrTest, toStop chan int) {
 	go func() {
-        waitForChannelStop := make(chan bool, 1)
-        watchControlChannel(test, waitForChannelStop)
-        <-waitForChannelStop
+		waitForChannelStop := make(chan bool, 1)
+		watchControlChannel(test, waitForChannelStop)
+		<-waitForChannelStop
 		toStop <- serverDone
 	}()
 }
@@ -234,10 +234,9 @@ func runPpsTest(test *ethrTest) {
 	for th := uint32(0); th < test.testParam.NumThreads; th++ {
 		go func() {
 			buff := make([]byte, test.testParam.BufferSize)
-            raddr, err := net.ResolveUDPAddr(protoUDP, server+":"+udpPpsPort)
-			conn, err := net.DialUDP(protoUDP, nil, raddr)
+			conn, err := net.Dial(protoUDP, server+":"+udpPpsPort)
 			if err != nil {
-                ui.printDbg("Unable to dial UDP, error: %v", err)
+				ui.printDbg("Unable to dial UDP, error: %v", err)
 				return
 			}
 			defer conn.Close()
@@ -245,11 +244,7 @@ func runPpsTest(test *ethrTest) {
 			lserver, lport, _ := net.SplitHostPort(conn.LocalAddr().String())
 			ui.printMsg("[udp] local %s port %s connected to %s port %s",
 				lserver, lport, rserver, rport)
-			// Send the local port to server, so it can create a "connected"
-            // UDP socket.
-            ethrMsg := createBgnMsg(lport)
-            sendSessionMsg(test.enc, ethrMsg)
-		    blen := len(buff)
+			blen := len(buff)
 		ExitForLoop:
 			for {
 				select {
@@ -258,7 +253,7 @@ func runPpsTest(test *ethrTest) {
 				default:
 					n, err := conn.Write(buff)
 					if err != nil {
-                        ui.printDbg("%v", err)
+						ui.printDbg("%v", err)
 						continue
 					}
 					if n < blen {

--- a/clientui.go
+++ b/clientui.go
@@ -30,9 +30,11 @@ func (u *clientUi) printErr(format string, a ...interface{}) {
 }
 
 func (u *clientUi) printDbg(format string, a ...interface{}) {
-	s := fmt.Sprintf(format, a...)
-	logDbg(s)
-	fmt.Println(s)
+    if logDebug {
+        s := fmt.Sprintf(format, a...)
+        logDbg(s)
+        fmt.Println(s)
+    }
 }
 
 func (u *clientUi) paint() {

--- a/serverui.go
+++ b/serverui.go
@@ -307,6 +307,7 @@ func (u *serverCli) printMsg(format string, a ...interface{}) {
 
 func (u *serverCli) printDbg(format string, a ...interface{}) {
 	s := fmt.Sprintf(format, a...)
+	fmt.Println(s)
 	logDbg(s)
 }
 

--- a/serverui.go
+++ b/serverui.go
@@ -164,13 +164,15 @@ func (u *serverTui) printErr(format string, a ...interface{}) {
 }
 
 func (u *serverTui) printDbg(format string, a ...interface{}) {
-	s := fmt.Sprintf(format, a...)
-	logDbg(s)
-	ss := splitString(s, u.errW)
-	u.ringLock.Lock()
-	u.errRing = u.errRing[len(ss):]
-	u.errRing = append(u.errRing, ss...)
-	u.ringLock.Unlock()
+    if logDebug {
+        s := fmt.Sprintf(format, a...)
+        logDbg(s)
+        ss := splitString(s, u.errW)
+        u.ringLock.Lock()
+        u.errRing = u.errRing[len(ss):]
+        u.errRing = append(u.errRing, ss...)
+        u.ringLock.Unlock()
+    }
 }
 
 func (u *serverTui) emitTestResultBegin() {
@@ -306,9 +308,11 @@ func (u *serverCli) printMsg(format string, a ...interface{}) {
 }
 
 func (u *serverCli) printDbg(format string, a ...interface{}) {
-	s := fmt.Sprintf(format, a...)
-	fmt.Println(s)
-	logDbg(s)
+    if logDebug {
+        s := fmt.Sprintf(format, a...)
+        fmt.Println(s)
+        logDbg(s)
+    }
 }
 
 func (u *serverCli) printErr(format string, a ...interface{}) {

--- a/session.go
+++ b/session.go
@@ -11,6 +11,7 @@ import (
 	"net"
 	"os"
 	"sync"
+    "fmt"
 )
 
 type EthrTestType uint32
@@ -96,6 +97,7 @@ type ethrTest struct {
 	ctrlConn   net.Conn
 	enc        *gob.Encoder
 	dec        *gob.Decoder
+    rcvdMsgs   chan *EthrMsg
 	testParam  EthrTestParam
 	testResult ethrTestResult
 	done       chan struct{}
@@ -155,6 +157,7 @@ func newTest(remoteAddr string, conn net.Conn, testParam EthrTestParam, enc *gob
 	test.ctrlConn = conn
 	test.enc = enc
 	test.dec = dec
+    test.rcvdMsgs = make(chan *EthrMsg)
 	test.testParam = testParam
 	test.done = make(chan struct{})
 	test.connList = list.New()
@@ -232,6 +235,20 @@ func (test *ethrTest) connListDo(f func(*ethrConn)) {
 		ec := e.Value.(*ethrConn)
 		f(ec)
 	}
+}
+
+func watchControlChannel(test *ethrTest, waitForChannelStop chan bool) {
+	go func() {
+        for {
+            ethrMsg := recvSessionMsg(test.dec)
+            if ethrMsg.Type == EthrInv {
+                break
+            }
+            test.rcvdMsgs <- ethrMsg
+            fmt.Println(ethrMsg)
+        }
+		waitForChannelStop <- true
+	}()
 }
 
 func recvSessionMsg(dec *gob.Decoder) (ethrMsg *EthrMsg) {

--- a/session.go
+++ b/session.go
@@ -8,10 +8,10 @@ package main
 import (
 	"container/list"
 	"encoding/gob"
+	"fmt"
 	"net"
 	"os"
 	"sync"
-    "fmt"
 )
 
 type EthrTestType uint32
@@ -97,7 +97,7 @@ type ethrTest struct {
 	ctrlConn   net.Conn
 	enc        *gob.Encoder
 	dec        *gob.Decoder
-    rcvdMsgs   chan *EthrMsg
+	rcvdMsgs   chan *EthrMsg
 	testParam  EthrTestParam
 	testResult ethrTestResult
 	done       chan struct{}
@@ -157,7 +157,7 @@ func newTest(remoteAddr string, conn net.Conn, testParam EthrTestParam, enc *gob
 	test.ctrlConn = conn
 	test.enc = enc
 	test.dec = dec
-    test.rcvdMsgs = make(chan *EthrMsg)
+	test.rcvdMsgs = make(chan *EthrMsg)
 	test.testParam = testParam
 	test.done = make(chan struct{})
 	test.connList = list.New()
@@ -239,14 +239,14 @@ func (test *ethrTest) connListDo(f func(*ethrConn)) {
 
 func watchControlChannel(test *ethrTest, waitForChannelStop chan bool) {
 	go func() {
-        for {
-            ethrMsg := recvSessionMsg(test.dec)
-            if ethrMsg.Type == EthrInv {
-                break
-            }
-            test.rcvdMsgs <- ethrMsg
-            fmt.Println(ethrMsg)
-        }
+		for {
+			ethrMsg := recvSessionMsg(test.dec)
+			if ethrMsg.Type == EthrInv {
+				break
+			}
+			test.rcvdMsgs <- ethrMsg
+			fmt.Println(ethrMsg)
+		}
 		waitForChannelStop <- true
 	}()
 }

--- a/utils.go
+++ b/utils.go
@@ -15,17 +15,32 @@ import (
 	"unicode/utf8"
 )
 
+//
+// TODO: Use a better way to define ports. The core logic is:
+// Find a base port, such as 9999, and the Bandwidth is: base - 0,
+// Cps is base - 1, Pps is base - 2 and Latency is base - 3
+//
 const (
-	hostAddr          = ""
-	ctrlPort          = "9991"
-	tcpBandwidthPort  = "9999"
-	tcpCpsPort        = "9998"
-	tcpPpsPort        = "9997"
-	tcpLatencyPort    = "9996"
-	udpPpsPort        = "9997"
-	httpBandwidthPort = "8080"
-	protoTCP          = "tcp"
-	protoUDP          = "udp"
+	hostAddr           = ""
+	ctrlPort           = "8888"
+	tcpBandwidthPort   = "9999"
+	tcpCpsPort         = "9998"
+	tcpPpsPort         = "9997"
+	tcpLatencyPort     = "9996"
+	udpBandwidthPort   = "9999"
+	udpCpsPort         = "9998"
+	udpPpsPort         = "9997"
+	udpLatencyPort     = "9996"
+	httpBandwidthPort  = "9899"
+	httpCpsPort        = "9898"
+	httpPpsPort        = "9897"
+	httpLatencyPort    = "9896"
+	httpsBandwidthPort = "9799"
+	httpsCpsPort       = "9798"
+	httpsPpsPort       = "9797"
+	httpsLatencyPort   = "9796"
+	protoTCP           = "tcp"
+	protoUDP           = "udp"
 )
 
 var gDone = false


### PR DESCRIPTION
Code cleanup before building support for connected UDP. Connected UDP is a feature that provides filtering in UDP by calling DialUDP from both sides. In current implementation, UDP server can receive unsolicited traffic and thus it has to look up test every time. This is expensive, and can be avoided with connected UDP feature.