### PR TITLE
fix wrong type durationStr in ethr.go

### DIFF
--- a/ethr.go
+++ b/ethr.go
@@ -113,7 +113,7 @@ func main() {
 	duration, err := time.ParseDuration(*durationStr)
 	if err != nil {
 		fmt.Printf("Invalid value \"%s\" specified for parameter \"-d\".\n",
-			durationStr)
+			*durationStr)
 		flag.PrintDefaults()
 		os.Exit(1)
 	}


### PR DESCRIPTION
I found the mismatch types of durationStr in printf
```
$ go test ./...
# github.com/Microsoft/Ethr
./ethr.go:115: Printf format %s has arg durationStr of wrong type *string

```
I fixed this PR. please check it.