### PR TITLE
Move stopStatsTimer in defer runServer #40

### DIFF
--- a/server.go
+++ b/server.go
@@ -20,6 +20,7 @@ import (
 )
 
 func runServer(testParam EthrTestParam, showUI bool) {
+	defer stopStatsTimer()
 	initServer(showUI)
 	l := runControlChannel()
 	defer l.Close()
@@ -36,7 +37,6 @@ func runServer(testParam EthrTestParam, showUI bool) {
 		}
 		go handleRequest(conn)
 	}
-	stopStatsTimer()
 }
 
 func initServer(showUI bool) {


### PR DESCRIPTION
#40 
i fix go vet failed which sweep unreachable code.

before:
```
$ go vet ./...
# github.com/MicroSoft/Ethr
./server.go:39: unreachable code
```
after:
```
$ go vet ./...
$
```

go vet command in details, please read docs 
https://golang.org/cmd/vet/