### PR TITLE
Fix wrong function name for darwin build

### DIFF
--- a/plt_darwin.go
+++ b/plt_darwin.go
@@ -48,7 +48,7 @@ func getNetDevStats(stats *ethrNetStat) {
 	}
 }
 
-func getTcpStats(stats *ethrNetStat) {
+func getTCPStats(stats *ethrNetStat) {
 	var data C.struct_tcpstat
 	rawData, err := unix.SysctlRaw("net.inet.tcp.stats")
 	if err != nil {


### PR DESCRIPTION
The build for darwin is currently broken due to missing `getTCPStats` function, that exists with older `getTcpStats` name.

This PR renames the function to fix the build.