### PR TITLE
Fix ethr when using default ports

### DIFF
--- a/ethr.go
+++ b/ethr.go
@@ -147,9 +147,7 @@ func main() {
 		os.Exit(1)
 	}
 
-    if *portStr != "" {
-        generatePortNumbers(*portStr)
-    }
+    generatePortNumbers(*portStr)
 
 	logFileName := *outputFile
 	if *isServer {


### PR DESCRIPTION
After #50 `ethr` can't be used without passing custom ports. This should fix that