### PR TITLE
fix a runtime error thrown when running on x86-32

### DIFF
--- a/session.go
+++ b/session.go
@@ -204,11 +204,11 @@ type ethrServerParam struct {
 var ipVer ethrIPVer = ethrIPAny
 
 type ethrConn struct {
+	data    uint64
 	test    *ethrTest
 	conn    net.Conn
 	elem    *list.Element
 	fd      uintptr
-	data    uint64
 	retrans uint64
 }
 


### PR DESCRIPTION
When compiling ethr for a x86-32 system (i.e. windows/386), running ethr as client throws this runtime error:
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal 0xc0000005 code=0x0 addr=0x0 pc=0x401ebc]

goroutine 14 [running]:
runtime/internal/atomic.Xadd64(0x11864824, 0x3e80, 0x0, 0x3e80, 0x3e80)
        C:/Go/src/runtime/internal/atomic/asm_386.s:102 +0xc
main.runTCPBandwidthTest.func1(0x1180a0d0, 0xc, 0x118362c0, 0x118d4000, 0x3e80, 0x3e80)
        D:/ssambi/Documents/GitHub/ethr/client.go:202 +0x464
created by main.runTCPBandwidthTest
        D:/ssambi/Documents/GitHub/ethr/client.go:169 +0x142
```

It's caused by data alignment, so moving the variable used in atomic instruction will solve.

See:

- https://github.com/golang/go/issues/5278

- https://stackoverflow.com/questions/28670232/atomic-addint64-causes-invalid-memory-address-or-nil-pointer-dereference