### PR TITLE
Load balancer support via External Mode

### DIFF
--- a/ethr.go
+++ b/ethr.go
@@ -266,7 +266,7 @@ func validateTestParam(mode ethrMode, testParam EthrTestParam) bool {
 			return false
 		}
 	} else if mode == ethrModeExtClient {
-		if testType != ConnLatency || protocol != TCP {
+		if (protocol != TCP) || (testType != ConnLatency && testType != Bandwidth) {
 			emitUnsupportedTest(testParam)
 			return false
 		}

--- a/ethr.go
+++ b/ethr.go
@@ -85,7 +85,6 @@ func main() {
 			printUsageError("Invalid arguments, \"-c\" cannot be used with \"-s\".")
 		}
 		if xMode {
-			printUsageError("External mode is not supported for server (yet).")
 			mode = ethrModeExtServer
 		} else {
 			mode = ethrModeServer
@@ -195,6 +194,8 @@ func main() {
 			switch mode {
 			case ethrModeServer:
 				logFileName = "ethrs.log"
+			case ethrModeExtServer:
+				logFileName = "ethrxs.log"
 			case ethrModeClient:
 				logFileName = "ethrc.log"
 			case ethrModeExtClient:
@@ -210,6 +211,8 @@ func main() {
 	switch mode {
 	case ethrModeServer:
 		runServer(testParam, serverParam)
+	case ethrModeExtServer:
+		runXServer(testParam, serverParam)
 	case ethrModeClient:
 		runClient(testParam, clientParam, *clientDest)
 	case ethrModeExtClient:

--- a/session.go
+++ b/session.go
@@ -250,7 +250,7 @@ func newTest(remoteAddr string, conn net.Conn, testParam EthrTestParam, enc *gob
 
 	test, found := session.tests[testParam.TestID]
 	if found {
-		return nil, os.ErrExist
+		return test, os.ErrExist
 	}
 	session.testCount++
 	test = &ethrTest{}
@@ -304,7 +304,17 @@ func getTest(remoteAddr string, proto EthrProtocol, testType EthrTestType) (test
 	if !found {
 		return
 	}
-	test, found = session.tests[EthrTestID{proto, testType}]
+	test, _ = session.tests[EthrTestID{proto, testType}]
+	return
+}
+
+func createOrGetTest(remoteAddr string, proto EthrProtocol, testType EthrTestType) (test *ethrTest) {
+	test = getTest(remoteAddr, proto, testType)
+	if test == nil {
+		testParam := EthrTestParam{TestID: EthrTestID{proto, testType}}
+		test, _ = newTest(remoteAddr, nil, testParam, nil, nil)
+		test.isActive = true
+	}
 	return
 }
 

--- a/session.go
+++ b/session.go
@@ -182,6 +182,7 @@ type ethrMode uint32
 const (
 	ethrModeInv ethrMode = iota
 	ethrModeServer
+	ethrModeExtServer
 	ethrModeClient
 	ethrModeExtClient
 )

--- a/session.go
+++ b/session.go
@@ -11,6 +11,7 @@ import (
 	"net"
 	"os"
 	"sync"
+	"sync/atomic"
 	"time"
 )
 
@@ -168,6 +169,7 @@ type ethrTest struct {
 	isActive   bool
 	session    *ethrSession
 	ctrlConn   net.Conn
+	refCount   int32
 	enc        *gob.Encoder
 	dec        *gob.Decoder
 	rcvdMsgs   chan *EthrMsg
@@ -197,6 +199,7 @@ const (
 
 type ethrClientParam struct {
 	duration time.Duration
+	gap      time.Duration
 }
 
 type ethrServerParam struct {
@@ -238,6 +241,10 @@ func deleteKey(key string) {
 func newTest(remoteAddr string, conn net.Conn, testParam EthrTestParam, enc *gob.Encoder, dec *gob.Decoder) (*ethrTest, error) {
 	gSessionLock.Lock()
 	defer gSessionLock.Unlock()
+	return newTestInternal(remoteAddr, conn, testParam, enc, dec)
+}
+
+func newTestInternal(remoteAddr string, conn net.Conn, testParam EthrTestParam, enc *gob.Encoder, dec *gob.Decoder) (*ethrTest, error) {
 	var session *ethrSession
 	session, found := gSessions[remoteAddr]
 	if !found {
@@ -256,6 +263,7 @@ func newTest(remoteAddr string, conn net.Conn, testParam EthrTestParam, enc *gob
 	test = &ethrTest{}
 	test.session = session
 	test.ctrlConn = conn
+	test.refCount = 0
 	test.enc = enc
 	test.dec = dec
 	test.rcvdMsgs = make(chan *EthrMsg)
@@ -270,6 +278,10 @@ func newTest(remoteAddr string, conn net.Conn, testParam EthrTestParam, enc *gob
 func deleteTest(test *ethrTest) {
 	gSessionLock.Lock()
 	defer gSessionLock.Unlock()
+	deleteTestInternal(test)
+}
+
+func deleteTestInternal(test *ethrTest) {
 	session := test.session
 	testID := test.testParam.TestID
 	//
@@ -297,9 +309,13 @@ func deleteTest(test *ethrTest) {
 }
 
 func getTest(remoteAddr string, proto EthrProtocol, testType EthrTestType) (test *ethrTest) {
-	test = nil
 	gSessionLock.RLock()
 	defer gSessionLock.RUnlock()
+	return getTestInternal(remoteAddr, proto, testType)
+}
+
+func getTestInternal(remoteAddr string, proto EthrProtocol, testType EthrTestType) (test *ethrTest) {
+	test = nil
 	session, found := gSessions[remoteAddr]
 	if !found {
 		return
@@ -308,14 +324,36 @@ func getTest(remoteAddr string, proto EthrProtocol, testType EthrTestType) (test
 	return
 }
 
-func createOrGetTest(remoteAddr string, proto EthrProtocol, testType EthrTestType) (test *ethrTest) {
-	test = getTest(remoteAddr, proto, testType)
+func createOrGetTest(remoteAddr string, proto EthrProtocol, testType EthrTestType) (test *ethrTest, isNew bool) {
+	gSessionLock.Lock()
+	defer gSessionLock.Unlock()
+	isNew = false
+	test = getTestInternal(remoteAddr, proto, testType)
 	if test == nil {
+		isNew = true
 		testParam := EthrTestParam{TestID: EthrTestID{proto, testType}}
-		test, _ = newTest(remoteAddr, nil, testParam, nil, nil)
+		test, _ = newTestInternal(remoteAddr, nil, testParam, nil, nil)
 		test.isActive = true
 	}
+	atomic.AddInt32(&test.refCount, 1)
 	return
+}
+
+func safeDeleteTest(test *ethrTest) bool {
+	gSessionLock.Lock()
+	defer gSessionLock.Unlock()
+	if atomic.AddInt32(&test.refCount, -1) == 0 {
+		deleteTestInternal(test)
+		return true
+	}
+	return false
+}
+
+func addRef(test *ethrTest) {
+	gSessionLock.Lock()
+	defer gSessionLock.Unlock()
+	// TODO: Since we already take lock, atomic is not needed. Fix this later.
+	atomic.AddInt32(&test.refCount, 1)
 }
 
 func (test *ethrTest) newConn(conn net.Conn) (ec *ethrConn) {

--- a/xclient.go
+++ b/xclient.go
@@ -20,18 +20,18 @@ func runXClient(testParam EthrTestParam, clientParam ethrClientParam, server str
 		ui.printErr("Failed to create the new test.")
 		return
 	}
-	xcRunTest(test, clientParam.duration)
+	xcRunTest(test, clientParam.duration, clientParam.gap)
 }
 
 func initXClient() {
 	initClientUI()
 }
 
-func xcRunTest(test *ethrTest, d time.Duration) {
+func xcRunTest(test *ethrTest, d, g time.Duration) {
 	startStatsTimer()
 	if test.testParam.TestID.Protocol == TCP {
 		if test.testParam.TestID.Type == ConnLatency {
-			go xcRunTCPConnLatencyTest(test)
+			go xcRunTCPConnLatencyTest(test, g)
 		} else if test.testParam.TestID.Type == Bandwidth {
 			go xcRunTCPBandwidthTest(test)
 		}
@@ -41,19 +41,17 @@ func xcRunTest(test *ethrTest, d time.Duration) {
 	runDurationTimer(d, toStop)
 	handleCtrlC(toStop)
 	reason := <-toStop
+	close(test.done)
+	stopStatsTimer()
 	switch reason {
 	case timeout:
 		ui.printMsg("Ethr done, duration: " + d.String() + ".")
 	case interrupt:
 		ui.printMsg("Ethr done, received interrupt signal.")
 	}
-	ui.printMsg("")
-	close(test.done)
-	stopStatsTimer()
-	time.Sleep(time.Second)
 }
 
-func xcRunTCPConnLatencyTest(test *ethrTest) {
+func xcRunTCPConnLatencyTest(test *ethrTest, g time.Duration) {
 	server := test.session.remoteAddr
 	// TODO: Override NumThreads for now, fix it later to support parallel
 	// threads.
@@ -81,7 +79,8 @@ func xcRunTCPConnLatencyTest(test *ethrTest) {
 					conn, err := net.Dial(tcp(ipVer), server)
 					if err != nil {
 						lost++
-						ui.printErr("Unable to dial TCP connection to [%s], error: %v", server, err)
+						ui.printDbg("Unable to dial TCP connection to [%s], error: %v", server, err)
+						ui.printMsg("[tcp] %sConnection %s: Timed out", warmupText, server)
 						continue
 					}
 					t1 := time.Since(t0)
@@ -109,14 +108,31 @@ func xcRunTCPConnLatencyTest(test *ethrTest) {
 						tcpconn.SetLinger(0)
 					}
 					conn.Close()
-
 					t1 = time.Since(t0)
-					if t1 < time.Second {
-						time.Sleep(time.Second - t1)
+					if t1 < g {
+						time.Sleep(g - t1)
 					}
 				}
 			}
 		}()
+	}
+}
+
+func xcCloseConn(conn net.Conn, test *ethrTest) {
+	test.delConn(conn)
+	err := conn.Close()
+	if err != nil {
+		ui.printDbg("Failed to close TCP connection, error: %v", err)
+	}
+	xcDeleteTest(test)
+}
+
+func xcDeleteTest(test *ethrTest) {
+	if test != nil {
+		if safeDeleteTest(test) {
+			ui.printMsg("Ethr done, server terminated the session.")
+			os.Exit(0)
+		}
 	}
 }
 
@@ -131,17 +147,18 @@ func xcRunTCPBandwidthTest(test *ethrTest) {
 		go func() {
 			conn, err := net.Dial(tcp(ipVer), server)
 			if err != nil {
-				ui.printErr("%v", err)
+				ui.printErr("Error in dialing TCP connection: %v", err)
 				os.Exit(1)
 				return
 			}
-			defer conn.Close()
 			ec := test.newConn(conn)
 			rserver, rport, _ := net.SplitHostPort(conn.RemoteAddr().String())
 			lserver, lport, _ := net.SplitHostPort(conn.LocalAddr().String())
 			ui.printMsg("[%3d] local %s port %s connected to %s port %s",
 				ec.fd, lserver, lport, rserver, rport)
 			blen := len(buff)
+			addRef(test)
+			defer xcCloseConn(conn, test)
 		ExitForLoop:
 			for {
 				select {
@@ -152,14 +169,12 @@ func xcRunTCPBandwidthTest(test *ethrTest) {
 					if err != nil {
 						// ui.printErr(err)
 						// test.ctrlConn.Close()
-						// return
-						continue
+						return
 					}
 					if n < blen {
 						// ui.printErr("Partial write: " + strconv.Itoa(n))
 						// test.ctrlConn.Close()
-						// return
-						continue
+						return
 					}
 					atomic.AddUint64(&ec.data, uint64(blen))
 					atomic.AddUint64(&test.testResult.data, uint64(blen))

--- a/xclient.go
+++ b/xclient.go
@@ -98,17 +98,15 @@ func xclientTCPLatencyTest(test *ethrTest) {
 						warmupText = ""
 						server = fmt.Sprintf("[%s]:%s", rserver, rport)
 					}
-					/*
-						tcpconn, ok := conn.(*net.TCPConn)
-						if ok {
-							tcpconn.SetLinger(0)
-						}
-					*/
+					tcpconn, ok := conn.(*net.TCPConn)
+					if ok {
+						tcpconn.SetLinger(0)
+					}
 					conn.Close()
 
 					t1 = time.Since(t0)
 					if t1 < time.Second {
-						time.Sleep(time.Second - t1)
+						// time.Sleep(time.Second - t1)
 					}
 				}
 			}

--- a/xserver.go
+++ b/xserver.go
@@ -6,207 +6,98 @@
 package main
 
 import (
-	"crypto/rand"
-	"crypto/rsa"
-	"crypto/tls"
-	"crypto/x509"
-	"crypto/x509/pkix"
-	"encoding/gob"
+	/*
+		"crypto/rand"
+		"crypto/rsa"
+		"crypto/tls"
+		"crypto/x509"
+		"crypto/x509/pkix"
+		"encoding/gob"
+	*/
 	"fmt"
-	"io"
-	"io/ioutil"
-	"math/big"
+	/*
+		"io"
+		"io/ioutil"
+		"math/big"
+	*/
 	"net"
-	"net/http"
+	/*
+		"net/http"
+	*/
 	"os"
-	"runtime"
-	"sort"
+	/*
+		"runtime"
+		"sort"
+	*/
 	"sync/atomic"
-	"time"
-)
+	/*
+		"time"
+	*/)
 
-var gCert []byte
-
-func runServer(testParam EthrTestParam, serverParam ethrServerParam) {
+func runXServer(testParam EthrTestParam, serverParam ethrServerParam) {
 	defer stopStatsTimer()
-	initServer(serverParam.showUI)
-	runTCPBandwidthServer()
-	runTCPCpsServer()
-	runTCPLatencyServer()
-	runHTTPBandwidthServer()
-	runHTTPSBandwidthServer()
-	l := runControlChannel()
-	defer l.Close()
+	initXServer(serverParam.showUI)
+	xserverTCPServer()
+	// runHTTPBandwidthServer()
+	// runHTTPSBandwidthServer()
 	startStatsTimer()
-	for {
-		conn, err := l.Accept()
-		if err != nil {
-			ui.printErr("Error accepting new control connection: %v", err)
-			continue
-		}
-		go handleRequest(conn)
-	}
+	toStop := make(chan int, 1)
+	handleCtrlC(toStop)
+	<-toStop
+	ui.printMsg("Ethr done, received interrupt signal.")
 }
 
-func initServer(showUI bool) {
+func initXServer(showUI bool) {
 	initServerUI(showUI)
 }
 
-func finiServer() {
+func finiXServer() {
 	ui.fini()
 	logFini()
 }
 
-func runControlChannel() net.Listener {
-	l, err := net.Listen(tcp(ipVer), hostAddr+":"+ctrlPort)
-	if err != nil {
-		finiServer()
-		fmt.Printf("Fatal error listening for control connections: %v", err)
-		os.Exit(1)
-	}
-	ui.printMsg("Listening on " + ctrlPort + " for control plane")
-	return l
-}
-
-func handleRequest(conn net.Conn) {
-	defer conn.Close()
-	dec := gob.NewDecoder(conn)
-	enc := gob.NewEncoder(conn)
-	ethrMsg := recvSessionMsg(dec)
-	if ethrMsg.Type != EthrSyn {
-		return
-	}
-	testParam := ethrMsg.Syn.TestParam
-	server, port, err := net.SplitHostPort(conn.RemoteAddr().String())
-	if err != nil {
-		ui.printDbg("RemoteAddr: Split host port failed: %v", err)
-		return
-	}
-	ethrUnused(port)
-	lserver, lport, err := net.SplitHostPort(conn.LocalAddr().String())
-	if err != nil {
-		ui.printDbg("LocalAddr: Split host port failed: %v", err)
-		return
-	}
-	ethrUnused(lserver, lport)
-	ui.printMsg("New control connection from " + server + ", port " + port)
-	ui.printMsg("Starting " + protoToString(testParam.TestID.Protocol) + " " +
-		testToString(testParam.TestID.Type) + " test from " + server)
-	test, err := newTest(server, conn, testParam, enc, dec)
-	if err != nil {
-		msg := "Rejected duplicate " + protoToString(testParam.TestID.Protocol) + " " +
-			testToString(testParam.TestID.Type) + " test from " + server
-		ui.printMsg(msg)
-		ethrMsg = createFinMsg(msg)
-		sendSessionMsg(enc, ethrMsg)
-		return
-	}
-	cleanupFunc := func() {
-		test.ctrlConn.Close()
-		close(test.done)
-		deleteTest(test)
-	}
-	ui.emitTestHdr()
-	if test.testParam.TestID.Protocol == UDP {
-		if test.testParam.TestID.Type == Bandwidth {
-			err = runUDPBandwidthServer(test)
-		} else if test.testParam.TestID.Type == Pps {
-			err = runUDPPpsServer(test)
-		}
-		if err != nil {
-			ui.printDbg("Error encounterd in running UDP test (%s): %v",
-				testToString(testParam.TestID.Type), err)
-			cleanupFunc()
-			return
-		}
-	}
-	ethrMsg = createAckMsg(gCert)
-	err = sendSessionMsg(enc, ethrMsg)
-	if err != nil {
-		ui.printErr("send session message: %v", err)
-		cleanupFunc()
-		return
-	}
-	// TODO: Enable this in future, right now there is not much value coming
-	// from this.
-	/**
-		ethrMsg = recvSessionMsg(dec)
-		if ethrMsg.Type != EthrAck {
-			cleanupFunc()
-			return
-		}
-	    **/
-	test.isActive = true
-	waitForChannelStop := make(chan bool, 1)
-	serverWatchControlChannel(test, waitForChannelStop)
-	<-waitForChannelStop
-	ui.printMsg("Ending " + testToString(testParam.TestID.Type) + " test from " + server)
-	test.isActive = false
-	cleanupFunc()
-	if len(gSessionKeys) > 0 {
-		ui.emitTestHdr()
-	}
-}
-
-func serverWatchControlChannel(test *ethrTest, waitForChannelStop chan bool) {
-	watchControlChannel(test, waitForChannelStop)
-}
-
-func runTCPBandwidthServer() {
+func xserverTCPServer() {
 	l, err := net.Listen(tcp(ipVer), hostAddr+":"+tcpBandwidthPort)
 	if err != nil {
-		finiServer()
-		fmt.Printf("Fatal error listening on "+tcpBandwidthPort+" for TCP bandwidth tests: %v", err)
+		finiXServer()
+		fmt.Printf("Fatal error listening on "+tcpBandwidthPort+" for TCP tests: %v", err)
 		os.Exit(1)
 	}
-	ui.printMsg("Listening on " + tcpBandwidthPort + " for TCP bandwidth tests")
+	ui.printMsg("Listening on " + tcpBandwidthPort + " for TCP tests")
 	go func(l net.Listener) {
 		defer l.Close()
 		for {
 			conn, err := l.Accept()
 			if err != nil {
-				ui.printErr("Error accepting new bandwidth connection: %v", err)
+				ui.printErr("Error accepting new TCP connection: %v", err)
 				continue
 			}
-			server, port, _ := net.SplitHostPort(conn.RemoteAddr().String())
-			test := getTest(server, TCP, Bandwidth)
-			if test == nil {
-				ui.printDbg("Received unsolicited TCP connection on port %s from %s port %s", tcpBandwidthPort, server, port)
-				conn.Close()
-				continue
-			}
-			go runTCPBandwidthHandler(conn, test)
+			go xserverTCPHandler(conn)
 		}
 	}(l)
 }
 
-func closeConn(conn net.Conn) {
-	err := conn.Close()
-	if err != nil {
-		ui.printDbg("Failed to close TCP connection, error: %v", err)
-	}
-}
-
-func runTCPBandwidthHandler(conn net.Conn, test *ethrTest) {
+func xserverTCPHandler(conn net.Conn) {
 	defer closeConn(conn)
-	size := test.testParam.BufferSize
-	bytes := make([]byte, size)
-ExitForLoop:
+	server, _, _ := net.SplitHostPort(conn.RemoteAddr().String())
+	test := createOrGetTest(server, TCP, Cps)
+	if test != nil {
+		atomic.AddUint64(&test.testResult.data, 1)
+	}
+	test = createOrGetTest(server, TCP, Bandwidth)
+	buff := make([]byte, 2048)
 	for {
-		select {
-		case <-test.done:
-			break ExitForLoop
-		default:
-			_, err := io.ReadFull(conn, bytes)
-			if err != nil {
-				ui.printDbg("Error receiving data on a connection for bandwidth test: %v", err)
-				continue
-			}
+		size, err := conn.Read(buff)
+		if err != nil {
+			return
+		}
+		if test != nil {
 			atomic.AddUint64(&test.testResult.data, uint64(size))
 		}
 	}
 }
 
+/*
 func runTCPCpsServer() {
 	l, err := net.Listen(tcp(ipVer), hostAddr+":"+tcpCpsPort)
 	if err != nil {
@@ -574,3 +465,4 @@ func runHTTPandHTTPSBandwidthHandler(w http.ResponseWriter, r *http.Request, p E
 		atomic.AddUint64(&test.testResult.data, uint64(r.ContentLength))
 	}
 }
+*/

--- a/xserver.go
+++ b/xserver.go
@@ -37,7 +37,7 @@ import (
 func runXServer(testParam EthrTestParam, serverParam ethrServerParam) {
 	defer stopStatsTimer()
 	initXServer(serverParam.showUI)
-	xserverTCPServer()
+	xsRunTCPServer()
 	// runHTTPBandwidthServer()
 	// runHTTPSBandwidthServer()
 	startStatsTimer()
@@ -56,7 +56,7 @@ func finiXServer() {
 	logFini()
 }
 
-func xserverTCPServer() {
+func xsRunTCPServer() {
 	l, err := net.Listen(tcp(ipVer), hostAddr+":"+tcpBandwidthPort)
 	if err != nil {
 		finiXServer()
@@ -79,6 +79,7 @@ func xserverTCPServer() {
 
 func xserverTCPHandler(conn net.Conn) {
 	defer closeConn(conn)
+	ui.emitTestHdr()
 	server, _, _ := net.SplitHostPort(conn.RemoteAddr().String())
 	test := createOrGetTest(server, TCP, Cps)
 	if test != nil {


### PR DESCRIPTION
Add support for external mode server. This also enables support for running Ethr behind a load balancer. In this mode, you can run server behind a load balancer on multiple nodes using ethr -s -m x and then use a single client to send traffic to all these servers, using ethr -c <server> -m x -n 64

This would create 64 sessions and start sending traffic. A load balancer in the middle can distribute these to different nodes running ethr.