### PR TITLE
Added support for HTTP latency testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,7 +245,7 @@ Protocol  | Bandwidth | Connections/s | Packets/s | Latency
 ------------- | ------------- | ------------- | ------------- | -------------
 TCP  | Yes | Yes | No | Yes
 UDP  | Yes | NA | Yes | No
-HTTP | Yes | No | No | No
+HTTP | Yes | No | No | Yes
 HTTPS | Yes | No | No | No
 ICMP | No | NA | No | No
 

--- a/client.go
+++ b/client.go
@@ -299,36 +299,8 @@ ExitForLoop:
 			// TODO temp code, fix it better, this is to allow server to do
 			// server side latency measurements as well.
 			_, _ = conn.Write(buff)
-			sum := int64(0)
-			for _, d := range latencyNumbers {
-				sum += d.Nanoseconds()
-			}
-			elapsed := time.Duration(sum / int64(rttCount))
-			sort.SliceStable(latencyNumbers, func(i, j int) bool {
-				return latencyNumbers[i] < latencyNumbers[j]
-			})
-			//
-			// Special handling for rttCount == 1. This prevents negative index
-			// in the latencyNumber index. The other option is to use
-			// roundUpToZero() but that is more expensive.
-			//
-			rttCountFixed := rttCount
-			if rttCountFixed == 1 {
-				rttCountFixed = 2
-			}
-			avg := elapsed
-			min := latencyNumbers[0]
-			max := latencyNumbers[rttCount-1]
-			p50 := latencyNumbers[((rttCountFixed*50)/100)-1]
-			p90 := latencyNumbers[((rttCountFixed*90)/100)-1]
-			p95 := latencyNumbers[((rttCountFixed*95)/100)-1]
-			p99 := latencyNumbers[((rttCountFixed*99)/100)-1]
-			p999 := latencyNumbers[uint64(((float64(rttCountFixed)*99.9)/100)-1)]
-			p9999 := latencyNumbers[uint64(((float64(rttCountFixed)*99.99)/100)-1)]
-			ui.emitLatencyResults(
-				test.session.remoteAddr,
-				protoToString(test.testParam.TestID.Protocol),
-				avg, min, max, p50, p90, p95, p99, p999, p9999)
+
+		    calcLatency(test, rttCount, latencyNumbers)
 		}
 	}
 }
@@ -487,7 +459,6 @@ ExitForLoop:
 
 func runHTTPLatencyTest(test *ethrTest) {
 	uri := test.session.remoteAddr
-	ui.printMsg("hi")
 	ui.printMsg("uri=%s", uri)
 	uri = "http://" + uri + ":" + httpLatencyPort
 
@@ -498,7 +469,6 @@ func runHTTPLatencyTest(test *ethrTest) {
 	
 	rttCount := test.testParam.RttCount
 	latencyNumbers := make([]time.Duration, rttCount)
-	ui.printMsg("%d",rttCount)
 	tr := &http.Transport{DisableCompression: true}
 	client := &http.Client{Transport: tr}
 ExitForLoop:
@@ -528,38 +498,41 @@ ExitForLoop:
 				e2 := time.Since(s1)
 				latencyNumbers[i] = e2
 			}
-			// TODO temp code, fix it better, this is to allow server to do
-			// server side latency measurements as well.
-			sum := int64(0)
-			for _, d := range latencyNumbers {
-				sum += d.Nanoseconds()
-			}
-			elapsed := time.Duration(sum / int64(rttCount))
-			sort.SliceStable(latencyNumbers, func(i, j int) bool {
-				return latencyNumbers[i] < latencyNumbers[j]
-			})
-			//
-			// Special handling for rttCount == 1. This prevents negative index
-			// in the latencyNumber index. The other option is to use
-			// roundUpToZero() but that is more expensive.
-			//
-			rttCountFixed := rttCount
-			if rttCountFixed == 1 {
-				rttCountFixed = 2
-			}
-			avg := elapsed
-			min := latencyNumbers[0]
-			max := latencyNumbers[rttCount-1]
-			p50 := latencyNumbers[((rttCountFixed*50)/100)-1]
-			p90 := latencyNumbers[((rttCountFixed*90)/100)-1]
-			p95 := latencyNumbers[((rttCountFixed*95)/100)-1]
-			p99 := latencyNumbers[((rttCountFixed*99)/100)-1]
-			p999 := latencyNumbers[uint64(((float64(rttCountFixed)*99.9)/100)-1)]
-			p9999 := latencyNumbers[uint64(((float64(rttCountFixed)*99.99)/100)-1)]
-			ui.emitLatencyResults(
-				test.session.remoteAddr,
-				protoToString(test.testParam.TestID.Protocol),
-				avg, min, max, p50, p90, p95, p99, p999, p9999)
+
+		    calcLatency(test, rttCount, latencyNumbers)
 		}
 	}
+}
+
+func calcLatency (test *ethrTest, rttCount uint32, latencyNumbers []time.Duration) {
+    sum := int64(0)
+	for _, d := range latencyNumbers {
+		sum += d.Nanoseconds()
+	}
+	elapsed := time.Duration(sum / int64(rttCount))
+	sort.SliceStable(latencyNumbers, func(i, j int) bool {
+		return latencyNumbers[i] < latencyNumbers[j]
+	})
+	//
+	// Special handling for rttCount == 1. This prevents negative index
+	// in the latencyNumber index. The other option is to use
+	// roundUpToZero() but that is more expensive.
+	//
+	rttCountFixed := rttCount
+	if rttCountFixed == 1 {
+		rttCountFixed = 2
+	}
+	avg := elapsed
+	min := latencyNumbers[0]
+	max := latencyNumbers[rttCount-1]
+	p50 := latencyNumbers[((rttCountFixed*50)/100)-1]
+	p90 := latencyNumbers[((rttCountFixed*90)/100)-1]
+	p95 := latencyNumbers[((rttCountFixed*95)/100)-1]
+	p99 := latencyNumbers[((rttCountFixed*99)/100)-1]
+	p999 := latencyNumbers[uint64(((float64(rttCountFixed)*99.9)/100)-1)]
+	p9999 := latencyNumbers[uint64(((float64(rttCountFixed)*99.99)/100)-1)]
+	ui.emitLatencyResults(
+		test.session.remoteAddr,
+		protoToString(test.testParam.TestID.Protocol),
+		avg, min, max, p50, p90, p95, p99, p999, p9999)
 }

--- a/client.go
+++ b/client.go
@@ -146,7 +146,11 @@ func runTest(test *ethrTest, d time.Duration) {
 	} else if test.testParam.TestID.Protocol == HTTP {
 		if test.testParam.TestID.Type == Bandwidth {
 			go runHTTPBandwidthTest(test)
+		} else if test.testParam.TestID.Type == Latency {
+			ui.emitLatencyHdr()
+			go runHTTPLatencyTest(test)
 		}
+
 	} else if test.testParam.TestID.Protocol == HTTPS {
 		if test.testParam.TestID.Type == Bandwidth {
 			go runHTTPSBandwidthTest(test)
@@ -477,6 +481,85 @@ ExitForLoop:
 				// ui.printDbg("%s", string(contents))
 			}
 			atomic.AddUint64(&test.testResult.data, uint64(test.testParam.BufferSize))
+		}
+	}
+}
+
+func runHTTPLatencyTest(test *ethrTest) {
+	uri := test.session.remoteAddr
+	ui.printMsg("hi")
+	ui.printMsg("uri=%s", uri)
+	uri = "http://" + uri + ":" + httpLatencyPort
+
+	buff := make([]byte, test.testParam.BufferSize)
+	for i := uint32(0); i < test.testParam.BufferSize; i++ {
+		buff[i] = 'x'
+	}
+	
+	rttCount := test.testParam.RttCount
+	latencyNumbers := make([]time.Duration, rttCount)
+	ui.printMsg("%d",rttCount)
+	tr := &http.Transport{DisableCompression: true}
+	client := &http.Client{Transport: tr}
+ExitForLoop:
+	for {
+	ExitSelect:
+		select {
+		case <-test.done:
+			break ExitForLoop
+		default:
+			for i := uint32(0); i < rttCount; i++ {
+				s1 := time.Now()
+				response, err := client.Post(uri, "text/plain", bytes.NewBuffer(buff))
+				if err != nil {
+					break ExitSelect
+				} else {
+					if response.StatusCode != http.StatusOK {
+						break ExitSelect
+					}
+					contents, err := ioutil.ReadAll(response.Body)
+					response.Body.Close()
+					if err != nil {
+						break ExitSelect	
+					}
+					ethrUnused(contents)
+				}
+				
+				e2 := time.Since(s1)
+				latencyNumbers[i] = e2
+			}
+			// TODO temp code, fix it better, this is to allow server to do
+			// server side latency measurements as well.
+			sum := int64(0)
+			for _, d := range latencyNumbers {
+				sum += d.Nanoseconds()
+			}
+			elapsed := time.Duration(sum / int64(rttCount))
+			sort.SliceStable(latencyNumbers, func(i, j int) bool {
+				return latencyNumbers[i] < latencyNumbers[j]
+			})
+			//
+			// Special handling for rttCount == 1. This prevents negative index
+			// in the latencyNumber index. The other option is to use
+			// roundUpToZero() but that is more expensive.
+			//
+			rttCountFixed := rttCount
+			if rttCountFixed == 1 {
+				rttCountFixed = 2
+			}
+			avg := elapsed
+			min := latencyNumbers[0]
+			max := latencyNumbers[rttCount-1]
+			p50 := latencyNumbers[((rttCountFixed*50)/100)-1]
+			p90 := latencyNumbers[((rttCountFixed*90)/100)-1]
+			p95 := latencyNumbers[((rttCountFixed*95)/100)-1]
+			p99 := latencyNumbers[((rttCountFixed*99)/100)-1]
+			p999 := latencyNumbers[uint64(((float64(rttCountFixed)*99.9)/100)-1)]
+			p9999 := latencyNumbers[uint64(((float64(rttCountFixed)*99.99)/100)-1)]
+			ui.emitLatencyResults(
+				test.session.remoteAddr,
+				protoToString(test.testParam.TestID.Protocol),
+				avg, min, max, p50, p90, p95, p99, p999, p9999)
 		}
 	}
 }

--- a/client.go
+++ b/client.go
@@ -459,7 +459,6 @@ ExitForLoop:
 
 func runHTTPLatencyTest(test *ethrTest) {
 	uri := test.session.remoteAddr
-	ui.printMsg("uri=%s", uri)
 	uri = "http://" + uri + ":" + httpLatencyPort
 
 	buff := make([]byte, test.testParam.BufferSize)
@@ -494,7 +493,6 @@ ExitForLoop:
 					}
 					ethrUnused(contents)
 				}
-				
 				e2 := time.Since(s1)
 				latencyNumbers[i] = e2
 			}

--- a/ethr.go
+++ b/ethr.go
@@ -413,7 +413,7 @@ func validateTestParam(mode ethrMode, testParam EthrTestParam) {
 				}
 			}
 		case HTTP:
-			if testType != Bandwidth {
+			if testType != Bandwidth && testType != Latency {
 				emitUnsupportedTest(testParam)
 			}
 		case HTTPS:

--- a/server.go
+++ b/server.go
@@ -448,7 +448,7 @@ func runHTTPBandwidthServer() {
 }
 
 func runHTTPBandwidthHandler(w http.ResponseWriter, r *http.Request) {
-	runHTTPandHTTPSBandwidthHandler(w, r, HTTP)
+	runHTTPandHTTPSHandler(w, r, HTTP, Bandwidth)
 }
 
 func runHTTPSBandwidthServer() {
@@ -474,7 +474,7 @@ func runHTTPSBandwidthServer() {
 }
 
 func runHTTPSBandwidthHandler(w http.ResponseWriter, r *http.Request) {
-	runHTTPandHTTPSBandwidthHandler(w, r, HTTPS)
+	runHTTPandHTTPSHandler(w, r, HTTPS, Bandwidth)
 }
 
 func runHTTPServer(l net.Listener, handler http.Handler) error {
@@ -557,7 +557,7 @@ func allLocalIPs() (ipList []net.IP) {
 	return
 }
 
-func runHTTPandHTTPSBandwidthHandler(w http.ResponseWriter, r *http.Request, p EthrProtocol) {
+func runHTTPandHTTPSHandler(w http.ResponseWriter, r *http.Request, p EthrProtocol, testType EthrTestType) {
 	_, err := ioutil.ReadAll(r.Body)
 	if err != nil {
 		ui.printDbg("Error reading HTTP body: %v", err)
@@ -565,7 +565,7 @@ func runHTTPandHTTPSBandwidthHandler(w http.ResponseWriter, r *http.Request, p E
 		return
 	}
 	server, _, _ := net.SplitHostPort(r.RemoteAddr)
-	test := getTest(server, p, Bandwidth)
+	test := getTest(server, p, testType)
 	if test == nil {
 		http.Error(w, "Unauthorized request.", http.StatusUnauthorized)
 		return
@@ -599,30 +599,5 @@ func runHTTPLatencyServer() {
 }
 
 func runHTTPLatencyHandler(w http.ResponseWriter, r *http.Request) {
-	runHTTPProtoLatencyHandler(w, r, HTTP)
-}
-
-func runHTTPProtoLatencyHandler(w http.ResponseWriter, r *http.Request, p EthrProtocol) {
-	_, err := ioutil.ReadAll(r.Body)
-	if err != nil {
-		return
-	}
-
- 	server, _, _ := net.SplitHostPort(r.RemoteAddr)
-	test := getTest(server, p, Latency)
-	if test == nil {
-		return
-	}
-
-	switch r.Method {
-	case "GET":
-		w.Write([]byte("OK."))
-	case "PUT":
-		w.Write([]byte("OK."))
-	case "POST":
-		w.Write([]byte("OK."))
-	default:
-		http.Error(w, "Only GET, PUT and POST are supported.", http.StatusMethodNotAllowed)
-		return
-	}
+	runHTTPandHTTPSHandler(w, r, HTTP, Latency)
 }

--- a/server.go
+++ b/server.go
@@ -581,8 +581,10 @@ func runHTTPandHTTPSHandler(w http.ResponseWriter, r *http.Request, p EthrProtoc
 		http.Error(w, "Only GET, PUT and POST are supported.", http.StatusMethodNotAllowed)
 		return
 	}
-	if r.ContentLength > 0 {
-		atomic.AddUint64(&test.testResult.data, uint64(r.ContentLength))
+	if (testType == Bandwidth) {
+		if r.ContentLength > 0 {
+			atomic.AddUint64(&test.testResult.data, uint64(r.ContentLength))
+		}
 	}
 }
 


### PR DESCRIPTION
Issue: #58 

I wanted to confirm that for http tests, only client request and server response latency is calculated at client side, which happens in this pull request.
We shouldn't do for server request and client response (as it doesn't make sense for http).