### PR TITLE
Fix error handling in establishSession()

### DIFF
--- a/client.go
+++ b/client.go
@@ -72,6 +72,7 @@ func establishSession(testParam EthrTestParam, server string) (test *ethrTest, e
 			err = fmt.Errorf("Unexpected control message received. %v", ethrMsg)
 		}
 		deleteTest(test)
+		return nil, err
 	}
 	gCert = ethrMsg.Ack.Cert
 	napDuration := ethrMsg.Ack.NapDuration
@@ -302,7 +303,7 @@ ExitForLoop:
 			// server side latency measurements as well.
 			_, _ = conn.Write(buff)
 
-		    calcLatency(test, rttCount, latencyNumbers)
+			calcLatency(test, rttCount, latencyNumbers)
 		}
 	}
 }
@@ -467,7 +468,7 @@ func runHTTPLatencyTest(test *ethrTest) {
 	for i := uint32(0); i < test.testParam.BufferSize; i++ {
 		buff[i] = 'x'
 	}
-	
+
 	rttCount := test.testParam.RttCount
 	latencyNumbers := make([]time.Duration, rttCount)
 	tr := &http.Transport{DisableCompression: true}
@@ -491,7 +492,7 @@ ExitForLoop:
 					contents, err := ioutil.ReadAll(response.Body)
 					response.Body.Close()
 					if err != nil {
-						break ExitSelect	
+						break ExitSelect
 					}
 					ethrUnused(contents)
 				}
@@ -499,13 +500,13 @@ ExitForLoop:
 				latencyNumbers[i] = e2
 			}
 
-		    calcLatency(test, rttCount, latencyNumbers)
+			calcLatency(test, rttCount, latencyNumbers)
 		}
 	}
 }
 
-func calcLatency (test *ethrTest, rttCount uint32, latencyNumbers []time.Duration) {
-    sum := int64(0)
+func calcLatency(test *ethrTest, rttCount uint32, latencyNumbers []time.Duration) {
+	sum := int64(0)
 	for _, d := range latencyNumbers {
 		sum += d.Nanoseconds()
 	}


### PR DESCRIPTION
In `establishSession()` if the `ethrMsg` returned from server is not `EthrAck` of type, test should be stopped with error but it went down to next procedure, which caused SEGV due to the access to a member of nil pointer(`ethrMsg.Ack.Cert`).

Just by adding `return nil, err` it can be avoided and the program finishes with expected error message.

### Before fixing it

```
ethr -c 100.100.100.210
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x6c907d]

goroutine 1 [running]:
main.establishSession(0x100000000, 0x3e8000000001, 0x3e8, 0xc000d66000, 0x11, 0xc00009e070, 0x80eae0, 0xc000d406e0)
        /mnt/c/Users/ykura/dev/ethr/client.go:79 +0x5ed
main.runClient(0x100000000, 0x3e8000000001, 0x3e8, 0x2540be400, 0x0, 0x7ffc341a8770, 0xf)
        /mnt/c/Users/ykura/dev/ethr/client.go:30 +0xd7
main.main()
        /mnt/c/Users/ykura/dev/ethr/ethr.go:396 +0x995
```

### With this fix

```shell-session
ethr -c 100.100.100.210
Rejected duplicate TCP Bandwidth test from 100.100.104.201
```
