### PR TITLE
Added linux sanity checking for /proc/net/dev

### DIFF
--- a/internal/stats/linux.go
+++ b/internal/stats/linux.go
@@ -9,6 +9,7 @@ package stats
 
 import (
 	"bufio"
+	"fmt"
 	"net"
 	"os"
 	"strconv"
@@ -75,6 +76,13 @@ func (s osStats) GetNetDevStats() ([]EthrNetDevStat, error) {
 func buildNetDevStat(line string) (EthrNetDevStat, error) {
 	fields := strings.Fields(line)
 	interfaceName := strings.TrimSuffix(fields[0], ":")
+
+	if len(fields) < 18 {
+		return EthrNetDevStat{}, errors.New(
+			fmt.Sprintf(
+				"buildNetDevStat: unexpected net stats file format, erroneous line %s"),
+			line)
+	}
 
 	rxInfo, err := toNetDevInfo(fields[1:9])
 	if err != nil {


### PR DESCRIPTION
Added a sanity check for the /proc/net/dev file for linux machines as formats may differ. This is a temporary/dirty fix and the code needs to be changed to handle differing formats/OS variants more elegantly if possible.

Issue #91 