### PR TITLE
Fix bug incorrectly parsing /proc/net/dev

### DIFF
--- a/internal/stats/linux.go
+++ b/internal/stats/linux.go
@@ -77,7 +77,7 @@ func buildNetDevStat(line string) (EthrNetDevStat, error) {
 	fields := strings.Fields(line)
 	interfaceName := strings.TrimSuffix(fields[0], ":")
 
-	if len(fields) < 18 {
+	if len(fields) < 17 {
 		return EthrNetDevStat{}, errors.New(
 			fmt.Sprintf(
 				"buildNetDevStat: unexpected net stats file format, erroneous line %s",


### PR DESCRIPTION
Fixes a bug for Linux-based machines which incorrectly parses /proc/net/dev