### PR TITLE
Remove hardcoded buffer of 1 from latency test on server and client(#1)

### DIFF
--- a/client.go
+++ b/client.go
@@ -260,9 +260,6 @@ func runTCPLatencyTest(test *ethrTest) {
 	}
 	defer conn.Close()
 	buffSize := test.testParam.BufferSize
-	// TODO Override buffer size to 1 for now. Evaluate if we need to allow
-	// client to specify the buffer size in future.
-	buffSize = 1
 	buff := make([]byte, buffSize)
 	for i := uint32(0); i < buffSize; i++ {
 		buff[i] = byte(i)

--- a/ethr.go
+++ b/ethr.go
@@ -16,6 +16,8 @@ import (
 )
 
 const defaultLogFileName = "./ethrs.log for server, ./ethrc.log for client"
+const latencyDefaultBufferLenStr = "1B"
+const defaultBufferLenStr = "16KB"
 
 var gVersion string
 
@@ -40,7 +42,7 @@ func main() {
 	clientDest := flag.String("c", "", "")
 	testTypePtr := flag.String("t", "", "")
 	thCount := flag.Int("n", 1, "")
-	bufLenStr := flag.String("l", "16KB", "")
+	bufLenStr := flag.String("l", "", "")
 	protocol := flag.String("p", "tcp", "")
 	outputFile := flag.String("o", defaultLogFileName, "")
 	debug := flag.Bool("debug", false, "")
@@ -112,6 +114,12 @@ func main() {
 		ipVer = ethrIPv4
 	} else if *use6 && !*use4 {
 		ipVer = ethrIPv6
+	}
+
+	//Default latency test to 1KB if length is not specified
+	switch *bufLenStr {
+	case "":
+		*bufLenStr = getDefaultBufferLenStr(*testTypePtr)
 	}
 
 	bufLen := unitToNumber(*bufLenStr)
@@ -221,6 +229,13 @@ func main() {
 	case ethrModeExtClient:
 		runXClient(testParam, clientParam, *clientDest)
 	}
+}
+
+func getDefaultBufferLenStr(testTypePtr string) string {
+	if testTypePtr == "l" {
+		return latencyDefaultBufferLenStr
+	}
+	return defaultBufferLenStr
 }
 
 func emitUnsupportedTest(testParam EthrTestParam) {

--- a/server.go
+++ b/server.go
@@ -281,9 +281,6 @@ func runTCPLatencyServer() {
 func runTCPLatencyHandler(conn net.Conn, test *ethrTest) {
 	defer conn.Close()
 	bytes := make([]byte, test.testParam.BufferSize)
-	// TODO Override buffer size to 1 for now. Evaluate if we need to allow
-	// client to specify the buffer size in future.
-	bytes = make([]byte, 1)
 	rttCount := test.testParam.RttCount
 	latencyNumbers := make([]time.Duration, rttCount)
 	for {


### PR DESCRIPTION
* Remove hardcoded buffer of 1 from latency test on server and client. We noticed that during latency tests, the buffer size was hardcoded to 1. That made us unable to test latency on certain packet sizes. 