### PR TITLE
Print 3 digits after decimal point for duration.

### DIFF
--- a/utils/utils.go
+++ b/utils/utils.go
@@ -27,7 +27,7 @@ func DurationToString(d time.Duration) string {
 			unit = "s"
 		}
 
-		result := strconv.FormatFloat(val, 'f', 2, 64)
+		result := strconv.FormatFloat(val, 'f', 3, 64)
 		return result + unit
 	}
 


### PR DESCRIPTION
When testing low latency lines, 2 digits precision is not enough.

By displaying 3 digits after decimal point, ethr latency test helps me to find out some of our switch would incur about 40us latency.