### PR TITLE
Fix handling of interrupt

### DIFF
--- a/xclient.go
+++ b/xclient.go
@@ -41,7 +41,7 @@ func xcRunTest(test *ethrTest, d, g time.Duration) {
 	test.isActive = true
 	toStop := make(chan int, 1)
 	runDurationTimer(d, toStop)
-	handleCtrlC(toStop)
+	handleInterrupt(toStop)
 	reason := <-toStop
 	close(test.done)
 	stopStatsTimer()

--- a/xserver.go
+++ b/xserver.go
@@ -21,7 +21,7 @@ func runXServer(testParam EthrTestParam, serverParam ethrServerParam) {
 	// runHTTPSBandwidthServer()
 	startStatsTimer()
 	toStop := make(chan int, 1)
-	handleCtrlC(toStop)
+	handleInterrupt(toStop)
 	<-toStop
 	ui.printMsg("Ethr done, received interrupt signal.")
 }


### PR DESCRIPTION
This PR fixes the case where `os.Kill` was being tried to be handled. But [os.Kill](https://golang.org/pkg/os/#Signal) is basically `syscall.SIGKILL` and `SIGKILL` can't be captured/ handled. Previously it was working because when a `SIGINT` (Interrupt) arrived, the control was given to the `case os.Kill` using `fallthrough` which was present in the `case os.Interrupt` of `switch` block which is wrong.

Also, renamed `handleCtrlC` to `handleInterrupt` because it's addresses the functionality better. `CtrlC` is just a key combination to generate program interrupts (or `SIGINT`) and there could be other possible ways (and more appropriate) to generate the same signals (eg. using `kill -2`).

Ref: [SIGTERM, SIGINT (GNU's doc on signals)](https://www.gnu.org/software/libc/manual/html_node/Termination-Signals.html)

Also, I was thinking to add `syscall.SIGTERM` so that the program exits gracefully when running inside containers as well like we are doing it `os.Interrupt`. If my proposal for SIGTERM seems fine, then I'd push another commit with this PR itself. Here's a sample program: https://play.golang.org/p/P9kOwGwUw1t