### PR TITLE
Use "go build" instead of "go get"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,4 +5,4 @@ WORKDIR /app
 ADD ./ /app
 
 RUN mkdir /out && \
-    go get ./...
+    go build .


### PR DESCRIPTION
With the migration to Go Modules, one should avoid the use of the "go get".