### PR TITLE
Fix the package name of go get pkg

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ docker run -e BINARY_NAME=ethr -e GOOS=darwin -v $(pwd):/out microsoft/ethr make
 ## Using go get
 
 ```
-go get github.com/Microsoft/ethr
+go get github.com/microsoft/ethr
 ```
 
 ## Using ArchLinux AUR


### PR DESCRIPTION
the package name is `github.com/microsoft/ethr`
https://github.com/microsoft/ethr/blob/aa636603a7179e83d5a3dca7083ff8dd01e2c2a8/go.mod#L1