### PR TITLE
Fix IP TOS header & build

### DIFF
--- a/ethr.go
+++ b/ethr.go
@@ -1,8 +1,8 @@
-//-----------------------------------------------------------------------------
+// -----------------------------------------------------------------------------
 // Copyright (C) Microsoft. All rights reserved.
 // Licensed under the MIT license.
 // See LICENSE.txt file in the project root for full license information.
-//-----------------------------------------------------------------------------
+// -----------------------------------------------------------------------------
 package main
 
 import (
@@ -239,6 +239,7 @@ func main() {
 			uint64(bwRate),
 			uint8(*tos)}
 		validateClientParams(testId, clientParam)
+		gTOS = uint8(*tos)
 
 		rServer := destination
 		runClient(testId, *title, clientParam, rServer)

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,10 @@ module github.com/microsoft/ethr
 require (
 	github.com/mattn/go-runewidth v0.0.9
 	github.com/nsf/termbox-go v0.0.0-20200418040025-38ba6e5628f1
-	golang.org/x/sys v0.0.0-20200918174421-af09f7315aff
+	golang.org/x/net v0.39.0
+	golang.org/x/sys v0.32.0
 )
 
-go 1.13
+go 1.23.0
+
+toolchain go1.24.1

--- a/go.sum
+++ b/go.sum
@@ -2,5 +2,7 @@ github.com/mattn/go-runewidth v0.0.9 h1:Lm995f3rfxdpd6TSmuVCHVb/QhupuXlYr8sCI/Qd
 github.com/mattn/go-runewidth v0.0.9/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
 github.com/nsf/termbox-go v0.0.0-20200418040025-38ba6e5628f1 h1:lh3PyZvY+B9nFliSGTn5uFuqQQJGuNrD0MLCokv09ag=
 github.com/nsf/termbox-go v0.0.0-20200418040025-38ba6e5628f1/go.mod h1:IuKpRQcYE1Tfu+oAQqaLisqDeXgjyyltCfsaoYN18NQ=
-golang.org/x/sys v0.0.0-20200918174421-af09f7315aff h1:1CPUrky56AcgSpxz/KfgzQWzfG09u5YOL8MvPYBlrL8=
-golang.org/x/sys v0.0.0-20200918174421-af09f7315aff/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/net v0.39.0 h1:ZCu7HMWDxpXpaiKdhzIfaltL9Lp31x/3fCP11bc6/fY=
+golang.org/x/net v0.39.0/go.mod h1:X7NRbYVEA+ewNkCNyJ513WmMdQ3BineSwVtN2zD/d+E=
+golang.org/x/sys v0.32.0 h1:s77OFDvIQeibCmezSnk/q6iAfkdiQaJi4VzroCFrN20=
+golang.org/x/sys v0.32.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=

--- a/plt_darwin.go
+++ b/plt_darwin.go
@@ -1,10 +1,10 @@
-// +build darwin
+//go:build darwin
 
-//-----------------------------------------------------------------------------
+// -----------------------------------------------------------------------------
 // Copyright (C) Microsoft. All rights reserved.
 // Licensed under the MIT license.
 // See LICENSE.txt file in the project root for full license information.
-//-----------------------------------------------------------------------------
+// -----------------------------------------------------------------------------
 package main
 
 import (

--- a/plt_linux.go
+++ b/plt_linux.go
@@ -1,10 +1,10 @@
-// +build linux
+//go:build linux
 
-//-----------------------------------------------------------------------------
+// -----------------------------------------------------------------------------
 // Copyright (C) Microsoft. All rights reserved.
 // Licensed under the MIT license.
 // See LICENSE.txt file in the project root for full license information.
-//-----------------------------------------------------------------------------
+// -----------------------------------------------------------------------------
 package main
 
 import (

--- a/plt_windows.go
+++ b/plt_windows.go
@@ -1,10 +1,10 @@
-// +build windows
+//go:build windows
 
-//-----------------------------------------------------------------------------
+// -----------------------------------------------------------------------------
 // Copyright (C) Microsoft. All rights reserved.
 // Licensed under the MIT license.
 // See LICENSE.txt file in the project root for full license information.
-//-----------------------------------------------------------------------------
+// -----------------------------------------------------------------------------
 package main
 
 import (


### PR DESCRIPTION
1. Ran `go mod tidy` to pull missing dependencies
2. Ran `go fix` to fix fmt buildtags in plt_ files
3. Added line in `ethr.go` to set gTOS

Ref:
- #158
- #156
- #154
- #180